### PR TITLE
allow query string in huggingface download link

### DIFF
--- a/rvc/lib/tools/model_download.py
+++ b/rvc/lib/tools/model_download.py
@@ -91,6 +91,9 @@ def download_from_url(url):
 
         elif "/blob/" in url or "/resolve/" in url:
             os.chdir(zips_path)
+
+            if url.endswith("?download=true"):
+                url = url.replace("?download=true", "")
             if "/blob/" in url:
                 url = url.replace("/blob/", "/resolve/")
 


### PR DESCRIPTION
If there's a "?download=true" query string in a hugginface link, it fails to download and extract the voice model