### PR TITLE
Match api arguments with README

### DIFF
--- a/main.py
+++ b/main.py
@@ -1078,7 +1078,7 @@ def parse_arguments():
 
     # Parser for 'api' mode
     api_parser = subparsers.add_parser("api", help="Run the API")
-    api_parser.add_argument("--ip", type=str, help="IP address", default="127.0.0.1")
+    api_parser.add_argument("--host", type=str, help="Host address", default="127.0.0.1")
     api_parser.add_argument("--port", type=str, help="Port", default="8000")
 
     return parser.parse_args()
@@ -1229,7 +1229,7 @@ def main():
             )
         elif args.mode == "api":
             run_api_script(
-                str(args.ip),
+                str(args.host),
                 str(args.port),
             )
     except Exception as error:


### PR DESCRIPTION
Hi, this commit resolves the `unrecognized arguments` error when following the example from the README at https://github.com/blaise-tk/RVC_CLI?tab=readme-ov-file#api.

Before, specifying a host with the `--host` argument would return the following error:

```
$ python main.py api --host 0.0.0.0
...
main.py: error: unrecognized arguments: --host 0.0.0.0
```